### PR TITLE
Switch extended controller

### DIFF
--- a/src/Controllers/RobotsTxtController.php
+++ b/src/Controllers/RobotsTxtController.php
@@ -1,7 +1,7 @@
 <?php
 namespace Gverschuur\RobotsTxt\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 
 class RobotsTxtController extends Controller
 {


### PR DESCRIPTION
The [controller in the app namespace](https://github.com/laravel/laravel/blob/master/app/Http/Controllers/Controller.php) extends the [controller in the illuminate namespace](https://github.com/laravel/framework/blob/master/src/Illuminate/Routing/Controller.php),

This is afaik the controller that is intended to get extended by packages.

Should solve #2 😸 