### PR TITLE
Laravel 11

### DIFF
--- a/.github/workflows/php-unittest.yml
+++ b/.github/workflows/php-unittest.yml
@@ -1,45 +1,50 @@
 name: Run tests
 
-on:
-  push
+on: push
 
 jobs:
   php-tests:
-      runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-      strategy:
-          matrix:
-              php: [8.0, 8.1, 8.2]
-              laravel: [9.*, 10.*]
-              dependency-version: [prefer-lowest, prefer-stable]
-              include:
-                  - laravel: 10.*
-                    testbench: 8.*
-                    phpunit: 10.*
-                  - laravel: 9.*
-                    testbench: 7.*
-                    phpunit: 9.*
-              exclude:
-                  - laravel: 10.*
-                    php: 8.0
+    strategy:
+      matrix:
+        php: [8.0, 8.1, 8.2]
+        laravel: ['9.*', '10.*', '11.*']
+        dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 10.*
+            testbench: 8.*
+            phpunit: 10.*
+          - laravel: 9.*
+            testbench: 7.*
+            phpunit: 9.*
+          - laravel: 11.*
+            testbench: 9.*
+            phpunit: 10.*
+        exclude:
+          - laravel: 10.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
 
-      name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
-      steps:
-          - name: Checkout code
-            uses: actions/checkout@v1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
 
-          - name: Setup PHP
-            uses: shivammathur/setup-php@v2
-            with:
-                php-version: ${{ matrix.php }}
-                extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
-                coverage: none
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
 
-          - name: Install dependencies
-            run: |
-                composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
-                composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
-
-          - name: Execute tests
-            run: vendor/bin/phpunit
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^9.0|^10.0"
+        "laravel/framework": "^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +29,7 @@
     "license": "MIT",
     "require-dev": {
         "phpunit/phpunit": "^9.0|^10.0",
-        "orchestra/testbench": "^7.0|^8.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
         "phpstan/phpstan": "^1.4"
     },
     "scripts": {


### PR DESCRIPTION
Laravel 11 compatibility.
The shift which ran at https://github.com/verschuur/laravel-robotstxt/pull/13 has a typo in the github actions, trying to force phpunit 8.2 with laravel 11. This PR copies that PR and changes that line to use v10 of phpunit.